### PR TITLE
fix: nil dereference when we get metrics from a resource that has not been collected properly

### DIFF
--- a/receiver/azuremonitorreceiver/scraper_batch.go
+++ b/receiver/azuremonitorreceiver/scraper_batch.go
@@ -457,6 +457,9 @@ func (s *azureBatchScraper) getBatchMetricsValues(ctx context.Context, subscript
 								if timeseriesElement.Data != nil {
 									if metricValues.ResourceID != nil {
 										res := s.resources[*subscription.SubscriptionID][*metricValues.ResourceID]
+										if res == nil {
+											continue
+										}
 										attributes := map[string]*string{}
 										for name, value := range res.attributes {
 											attributes[name] = value


### PR DESCRIPTION
I'm not expert in the Azure API requested but can it be because we apply a filter to get the resources and not when we get metrics. So metrics can be related to resources that are not existing in our map.

Anyway the nil dereference is well happening and that should be a quickfix of that.

``` panic: runtime error: invalid memory address or nil pointer dereference[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4088bd7]goroutine 104331026 [running]:github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver.(*azureBatchScraper).getBatchMetricsValues(0xc002e382d0, {0x9079f40, 0xc028252450}, 0xc030d90840, {0xc05c4f8300, 0x3c})github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver@v0.92.0/scraper_batch.go:444 +0x1437github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver.(*azureBatchScraper).scrape.func1.2(0xc0057f5fd0?, {0xc05c4f8300?, 0xc01010fa01?})github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver@v0.92.0/scraper_batch.go:211 +0x70created by github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver.(*azureBatchScraper).scrape.func1 in goroutine 104326312github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver@v0.92.0/scraper_batch.go:209 +0x165 ```

Happening with the following commit / line of code 
https://github.com/ahurtaud/opentelemetry-collector-contrib/blob/6a9091f609402b085301411a07a93b3c692afff4/receiver/azuremonitorreceiver/scraper_batch.go#L444
