### PR TITLE
feat: Allow to split result by dimension

### DIFF
--- a/receiver/azuremonitorreceiver/config.go
+++ b/receiver/azuremonitorreceiver/config.go
@@ -245,12 +245,13 @@ type Config struct {
 	CacheResources                    float64                       `mapstructure:"cache_resources"`
 	CacheResourcesDefinitions         float64                       `mapstructure:"cache_resources_definitions"`
 	MaximumNumberOfMetricsInACall     int                           `mapstructure:"maximum_number_of_metrics_in_a_call"`
-	MaximumNumberOfDimensionsInACall  int                           `mapstructure:"maximum_number_of_dimensions_in_a_call"`
+	MaximumNumberOfDimensionsInACall  int32                         `mapstructure:"maximum_number_of_dimensions_in_a_call"`
 	MaximumNumberOfRecordsPerResource int32                         `mapstructure:"maximum_number_of_records_per_resource"`
 	AppendTagsAsAttributes            bool                          `mapstructure:"append_tags_as_attributes"`
 	UseBatchAPI                       bool                          `mapstructure:"use_batch_api"`
 	DiscoverSubscription              bool                          `mapstructure:"discover_subscriptions"`
 	Region                            string                        `mapstructure:"region"`
+	SplitByDimensions                 *bool                         `mapstructure:"split_by_dimensions"`
 }
 
 const (
@@ -305,6 +306,5 @@ func (c Config) Validate() (err error) {
 	if c.UseBatchAPI && c.Region == "" && !c.DiscoverSubscription {
 		err = multierr.Append(err, errInvalidRegion)
 	}
-
 	return
 }

--- a/receiver/azuremonitorreceiver/factory.go
+++ b/receiver/azuremonitorreceiver/factory.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
@@ -19,6 +20,7 @@ import (
 const (
 	defaultCollectionInterval = 10 * time.Second
 	defaultCloud              = azureCloud
+	defaultSplitByDimensions  = true
 )
 
 var errConfigNotAzureMonitor = errors.New("Config was not a Azure Monitor receiver config")
@@ -46,6 +48,7 @@ func createDefaultConfig() component.Config {
 		Services:                          monitorServices,
 		Authentication:                    servicePrincipal,
 		Cloud:                             defaultCloud,
+		SplitByDimensions:                 to.Ptr(defaultSplitByDimensions),
 	}
 }
 

--- a/receiver/azuremonitorreceiver/factory_test.go
+++ b/receiver/azuremonitorreceiver/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumertest"
@@ -48,6 +49,7 @@ func TestNewFactory(t *testing.T) {
 					MaximumNumberOfRecordsPerResource: 10,
 					Authentication:                    servicePrincipal,
 					Cloud:                             defaultCloud,
+					SplitByDimensions:                 to.Ptr(defaultSplitByDimensions),
 				}
 
 				require.Equal(t, expectedCfg, factory.CreateDefaultConfig())

--- a/receiver/azuremonitorreceiver/scraper.go
+++ b/receiver/azuremonitorreceiver/scraper.go
@@ -396,6 +396,7 @@ func (s *azureScraper) getResourceMetricsValues(ctx context.Context, resourceID 
 				start,
 				end,
 				s.cfg.MaximumNumberOfRecordsPerResource,
+				*s.cfg.SplitByDimensions,
 			)
 			start = end
 
@@ -445,6 +446,7 @@ func getResourceMetricsValuesRequestOptions(
 	start int,
 	end int,
 	top int32,
+	splitByDimensions bool,
 ) armmonitor.MetricsClientListOptions {
 	resType := strings.Join(metrics[start:end], ",")
 	filter := armmonitor.MetricsClientListOptions{
@@ -455,7 +457,7 @@ func getResourceMetricsValuesRequestOptions(
 		Top:         to.Ptr(top),
 	}
 
-	if len(dimensionsStr) > 0 {
+	if splitByDimensions && len(dimensionsStr) > 0 {
 		var dimensionsFilter bytes.Buffer
 		dimensions := strings.Split(dimensionsStr, ",")
 		for i, dimension := range dimensions {

--- a/receiver/azuremonitorreceiver/scraper_batch_test.go
+++ b/receiver/azuremonitorreceiver/scraper_batch_test.go
@@ -1,0 +1,18 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package azuremonitorreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver"
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_newMetricsQueryFilterFromDimensions(t *testing.T) {
+	assert.Nil(t, newMetricsQueryFilterFromDimensions(nil))
+	assert.Nil(t, newMetricsQueryFilterFromDimensions([]string{}))
+	assert.Equal(t, to.Ptr("hello eq '*'"), newMetricsQueryFilterFromDimensions([]string{"hello"}))
+	assert.Equal(t, to.Ptr("hello eq '*' and hi eq '*'"), newMetricsQueryFilterFromDimensions([]string{"hello", "hi"}))
+}

--- a/receiver/azuremonitorreceiver/scraper_test.go
+++ b/receiver/azuremonitorreceiver/scraper_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
@@ -102,6 +103,7 @@ func TestAzureScraperStart(t *testing.T) {
 					MaximumNumberOfMetricsInACall: 20,
 					Services:                      monitorServices,
 					Authentication:                servicePrincipal,
+					SplitByDimensions:             to.Ptr(defaultSplitByDimensions),
 				}
 				s := &azureScraper{
 					cfg:                             customCfg,
@@ -130,6 +132,7 @@ func TestAzureScraperStart(t *testing.T) {
 					MaximumNumberOfMetricsInACall: 20,
 					Services:                      monitorServices,
 					Authentication:                workloadIdentity,
+					SplitByDimensions:             to.Ptr(defaultSplitByDimensions),
 				}
 				s := &azureScraper{
 					cfg:                             customCfg,
@@ -158,6 +161,7 @@ func TestAzureScraperStart(t *testing.T) {
 					MaximumNumberOfMetricsInACall: 20,
 					Services:                      monitorServices,
 					Authentication:                managedIdentity,
+					SplitByDimensions:             to.Ptr(defaultSplitByDimensions),
 				}
 				s := &azureScraper{
 					cfg:                             customCfg,
@@ -186,6 +190,7 @@ func TestAzureScraperStart(t *testing.T) {
 					MaximumNumberOfMetricsInACall: 20,
 					Services:                      monitorServices,
 					Authentication:                defaultCredentials,
+					SplitByDimensions:             to.Ptr(defaultSplitByDimensions),
 				}
 				s := &azureScraper{
 					cfg:                             customCfg,
@@ -738,7 +743,8 @@ func TestAzureScraperClientOptions(t *testing.T) {
 			name: "AzureCloud_options",
 			fields: fields{
 				cfg: &Config{
-					Cloud: azureCloud,
+					Cloud:             azureCloud,
+					SplitByDimensions: to.Ptr(defaultSplitByDimensions),
 				},
 			},
 			want: &arm.ClientOptions{
@@ -751,7 +757,8 @@ func TestAzureScraperClientOptions(t *testing.T) {
 			name: "AzureGovernmentCloud_options",
 			fields: fields{
 				cfg: &Config{
-					Cloud: azureGovernmentCloud,
+					Cloud:             azureGovernmentCloud,
+					SplitByDimensions: to.Ptr(defaultSplitByDimensions),
 				},
 			},
 			want: &arm.ClientOptions{
@@ -764,7 +771,8 @@ func TestAzureScraperClientOptions(t *testing.T) {
 			name: "AzureChinaCloud_options",
 			fields: fields{
 				cfg: &Config{
-					Cloud: azureChinaCloud,
+					Cloud:             azureChinaCloud,
+					SplitByDimensions: to.Ptr(defaultSplitByDimensions),
 				},
 			},
 			want: &arm.ClientOptions{


### PR DESCRIPTION
~To be tested with more dimensions and to be configurable.~
The existing code in scrape.go do exactly the same thing. It takes all the dimensions. So let's do the same and propose a general dimension filter later if this is problematic.

The config is a simple opt out config field ``split_by_dimension`` (default: true to not introduce a breaking change)
The README has not been updated as anyway, it's completely nude from the new configs.

Note that I will do the same PR in the otelcontrib codebase repository with the README update.
