### PR TITLE
Split by dimensions extension

### DIFF
--- a/receiver/azuremonitorreceiver/README.md
+++ b/receiver/azuremonitorreceiver/README.md
@@ -31,6 +31,8 @@ The following settings are optional:
 - `maximum_number_of_records_per_resource` (default = 10): Maximum number of records to fetch per resource.
 - `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 - `cloud` (default = `AzureCloud`): defines which Azure cloud to use. Valid values: `AzureCloud`, `AzureUSGovernment`, `AzureChinaCloud`.
+- `dimensions.enabled` (default = `true`): allows to opt out from automatically split by all the dimensions of the resource type.
+- `dimensions.overrides` (default = `{}`): if dimensions are enabled, it allows you to specify a set of dimensions for a particular metric. This is a two levels map with first key being the resource type and second key being the metric name. Programmatic value should be used for metric name https://learn.microsoft.com/en-us/azure/azure-monitor/reference/metrics-index
 
 Authenticating using service principal requires following additional settings:
 
@@ -99,6 +101,22 @@ receivers:
   azuremonitor:
     subscription_id: "${subscription_id}"
     auth: "default_credentials"
+```
+
+Overriding dimensions for a particular metric:
+```yaml
+receivers:
+  azuremonitor:
+    dimensions:
+      enabled: true
+      overrides:
+        "Microsoft.Network/azureFirewalls":
+          # Real example of an Azure limitation here:
+          # Dimensions exposed are Reason, Status, Protocol,
+          # but when selecting Protocol in the filters, it returns nothing.
+          # Note here that the metric display name is ``Network rules hit count`` but it's programmatic value is ``NetworkRuleHit``
+          # Ref: https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-network-azurefirewalls-metrics
+          "NetworkRuleHit": [Reason, Status]
 ```
 
 

--- a/receiver/azuremonitorreceiver/config.go
+++ b/receiver/azuremonitorreceiver/config.go
@@ -229,6 +229,11 @@ var (
 	}
 )
 
+type DimensionsConfig struct {
+	Enabled   *bool                          `mapstructure:"enabled"`
+	Overrides map[string]map[string][]string `mapstructure:"overrides"`
+}
+
 // Config defines the configuration for the various elements of the receiver agent.
 type Config struct {
 	scraperhelper.ControllerConfig    `mapstructure:",squash"`
@@ -251,7 +256,7 @@ type Config struct {
 	UseBatchAPI                       bool                          `mapstructure:"use_batch_api"`
 	DiscoverSubscription              bool                          `mapstructure:"discover_subscriptions"`
 	Region                            string                        `mapstructure:"region"`
-	SplitByDimensions                 *bool                         `mapstructure:"split_by_dimensions"`
+	Dimensions                        DimensionsConfig              `mapstructure:"dimensions"`
 }
 
 const (

--- a/receiver/azuremonitorreceiver/dimension_test.go
+++ b/receiver/azuremonitorreceiver/dimension_test.go
@@ -1,0 +1,171 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package azuremonitorreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver"
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
+	"github.com/stretchr/testify/require"
+)
+
+func newDimension(value string) *armmonitor.LocalizableString {
+	return to.Ptr(armmonitor.LocalizableString{Value: to.Ptr(value)})
+}
+
+func TestFilterDimensions(t *testing.T) {
+	type args struct {
+		dimensions   []*armmonitor.LocalizableString
+		cfg          DimensionsConfig
+		resourceType string
+		metricName   string
+	}
+
+	tests := []struct {
+		name     string
+		args     args
+		expected []string
+	}{
+		{
+			name: "always empty if dimensions disabled",
+			args: args{
+				dimensions: []*armmonitor.LocalizableString{
+					newDimension("foo"),
+					newDimension("bar"),
+				},
+				cfg: DimensionsConfig{
+					Enabled: to.Ptr(false),
+				},
+				resourceType: "rt1",
+				metricName:   "m1",
+			},
+			expected: nil,
+		},
+		{
+			name: "split by dimensions should be enabled by default",
+			args: args{
+				dimensions: []*armmonitor.LocalizableString{
+					newDimension("foo"),
+					newDimension("bar"),
+				},
+				cfg:          DimensionsConfig{}, // enabled by default
+				resourceType: "rt1",
+				metricName:   "m1",
+			},
+			expected: []string{"foo", "bar"},
+		},
+		{
+			name: "overrides takes precedence over input",
+			args: args{
+				dimensions: []*armmonitor.LocalizableString{
+					newDimension("foo"),
+					newDimension("bar"),
+				},
+				cfg: DimensionsConfig{
+					Enabled: to.Ptr(true),
+					Overrides: map[string]map[string][]string{
+						"rt1": {
+							"m1": {
+								"foo",
+							},
+						},
+					},
+				},
+				resourceType: "rt1",
+				metricName:   "m1",
+			},
+			expected: []string{"foo"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := filterDimensions(tt.args.dimensions, tt.args.cfg, tt.args.resourceType, tt.args.metricName)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestBuildDimensionsFilter(t *testing.T) {
+	type args struct {
+		dimensionsStr string
+	}
+
+	tests := []struct {
+		name     string
+		args     args
+		expected *string
+	}{
+		{
+			name: "empty given dimensions string",
+			args: args{
+				dimensionsStr: "",
+			},
+			expected: nil,
+		},
+		{
+			name: "build dimensions filter",
+			args: args{
+				dimensionsStr: "bar,foo",
+			},
+			expected: to.Ptr("bar eq '*' and foo eq '*'"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := buildDimensionsFilter(tt.args.dimensionsStr)
+			require.EqualValues(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestSerializeDimensions(t *testing.T) {
+	type args struct {
+		dimensions []string
+	}
+
+	tests := []struct {
+		name     string
+		args     args
+		expected string
+	}{
+		{
+			name: "empty given dimensions",
+			args: args{
+				dimensions: []string{},
+			},
+			expected: "",
+		},
+		{
+			name: "nil given dimensions",
+			args: args{
+				dimensions: []string{},
+			},
+			expected: "",
+		},
+		{
+			name: "reorder dimensions",
+			args: args{
+				dimensions: []string{"foo", "bar"},
+			},
+			expected: "bar,foo",
+		},
+		{
+			name: "trim spaces dimensions",
+			args: args{
+				dimensions: []string{"  bar", "foo "},
+			},
+			expected: "bar,foo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := serializeDimensions(tt.args.dimensions)
+			require.EqualValues(t, tt.expected, actual)
+		})
+	}
+}

--- a/receiver/azuremonitorreceiver/dimensions.go
+++ b/receiver/azuremonitorreceiver/dimensions.go
@@ -1,0 +1,66 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package azuremonitorreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver"
+
+import (
+	"bytes"
+	"sort"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
+)
+
+// filterDimensions transforms a list of azure dimensions into a list of string, taking in account the DimensionConfig
+// given by the user.
+func filterDimensions(dimensions []*armmonitor.LocalizableString, cfg DimensionsConfig, resourceType, metricName string) []string {
+	// Only skip if explicitly disabled. Enabled by default.
+	if cfg.Enabled != nil && !*cfg.Enabled {
+		return nil
+	}
+
+	// If dimensions are overridden for that resource type and metric name, we take it
+	if _, resourceTypeFound := cfg.Overrides[resourceType]; resourceTypeFound {
+		if newDimensions, metricNameFound := cfg.Overrides[resourceType][metricName]; metricNameFound {
+			return newDimensions
+		}
+	}
+	// Otherwise we get all dimensions
+	var result []string
+	for _, dimension := range dimensions {
+		result = append(result, *dimension.Value)
+	}
+	return result
+}
+
+// serializeDimensions build a comma separated string from trimmed, sorted dimensions list.
+// It is designed to be used as a key in scraper maps.
+func serializeDimensions(dimensions []string) string {
+	var dimensionsSlice []string
+	for _, dimension := range dimensions {
+		if trimmedDimension := strings.TrimSpace(dimension); len(trimmedDimension) > 0 {
+			dimensionsSlice = append(dimensionsSlice, trimmedDimension)
+		}
+	}
+	sort.Strings(dimensionsSlice)
+	return strings.Join(dimensionsSlice, ",")
+}
+
+// buildDimensionsFilter takes a serialized dimensions input to build an Azure Request filter that will allow us to
+// receive metrics values split by these dimensions.
+func buildDimensionsFilter(dimensionsStr string) *string {
+	if len(dimensionsStr) == 0 {
+		return nil
+	}
+	var dimensionsFilter bytes.Buffer
+	dimensions := strings.Split(dimensionsStr, ",")
+	for i, dimension := range dimensions {
+		dimensionsFilter.WriteString(dimension)
+		dimensionsFilter.WriteString(" eq '*'")
+		if i < len(dimensions)-1 {
+			dimensionsFilter.WriteString(" and ")
+		}
+	}
+	result := dimensionsFilter.String()
+	return &result
+}

--- a/receiver/azuremonitorreceiver/factory.go
+++ b/receiver/azuremonitorreceiver/factory.go
@@ -14,7 +14,6 @@ import (
 	"go.opentelemetry.io/collector/scraper"
 	"go.opentelemetry.io/collector/scraper/scraperhelper"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver/internal/metadata"
 )
 
@@ -49,7 +48,6 @@ func createDefaultConfig() component.Config {
 		Services:                          monitorServices,
 		Authentication:                    servicePrincipal,
 		Cloud:                             defaultCloud,
-		SplitByDimensions:                 to.Ptr(defaultSplitByDimensions),
 	}
 }
 

--- a/receiver/azuremonitorreceiver/factory_test.go
+++ b/receiver/azuremonitorreceiver/factory_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumertest"
@@ -49,7 +48,6 @@ func TestNewFactory(t *testing.T) {
 					MaximumNumberOfRecordsPerResource: 10,
 					Authentication:                    servicePrincipal,
 					Cloud:                             defaultCloud,
-					SplitByDimensions:                 to.Ptr(defaultSplitByDimensions),
 				}
 
 				require.Equal(t, expectedCfg, factory.CreateDefaultConfig())

--- a/receiver/azuremonitorreceiver/scraper.go
+++ b/receiver/azuremonitorreceiver/scraper.go
@@ -4,11 +4,9 @@
 package azuremonitorreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver"
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"regexp"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -64,6 +62,7 @@ type azureResource struct {
 	metricsByCompositeKey     map[metricsCompositeKey]*azureResourceMetrics
 	metricsDefinitionsUpdated time.Time
 	tags                      map[string]*string
+	resourceType              *string
 }
 
 type metricsCompositeKey struct {
@@ -281,8 +280,9 @@ func (s *azureScraper) getResources(ctx context.Context) {
 					attributes[attributeLocation] = resource.Location
 				}
 				s.resources[*resource.ID] = &azureResource{
-					attributes: attributes,
-					tags:       resource.Tags,
+					attributes:   attributes,
+					tags:         resource.Tags,
+					resourceType: resource.Type,
 				}
 			}
 			delete(existingResources, *resource.ID)
@@ -338,20 +338,13 @@ func (s *azureScraper) getResourceMetricsDefinitions(ctx context.Context, resour
 
 		for _, v := range nextResult.Value {
 			timeGrain := *v.MetricAvailabilities[0].TimeGrain
-			name := *v.Name.Value
-			compositeKey := metricsCompositeKey{timeGrain: timeGrain}
-
-			if len(v.Dimensions) > 0 {
-				var dimensionsSlice []string
-				for _, dimension := range v.Dimensions {
-					if len(strings.TrimSpace(*dimension.Value)) > 0 {
-						dimensionsSlice = append(dimensionsSlice, *dimension.Value)
-					}
-				}
-				sort.Strings(dimensionsSlice)
-				compositeKey.dimensions = strings.Join(dimensionsSlice, ",")
+			metricName := *v.Name.Value
+			dimensions := filterDimensions(v.Dimensions, s.cfg.Dimensions, *s.resources[resourceID].resourceType, metricName)
+			compositeKey := metricsCompositeKey{
+				timeGrain:  timeGrain,
+				dimensions: serializeDimensions(dimensions),
 			}
-			s.storeMetricsDefinition(resourceID, name, compositeKey)
+			s.storeMetricsDefinition(resourceID, metricName, compositeKey)
 		}
 	}
 	s.resources[resourceID].metricsDefinitionsUpdated = time.Now()
@@ -391,7 +384,6 @@ func (s *azureScraper) getResourceMetricsValues(ctx context.Context, resourceID 
 				start,
 				end,
 				s.cfg.MaximumNumberOfRecordsPerResource,
-				*s.cfg.SplitByDimensions,
 			)
 			start = end
 
@@ -439,32 +431,15 @@ func getResourceMetricsValuesRequestOptions(
 	start int,
 	end int,
 	top int32,
-	splitByDimensions bool,
 ) armmonitor.MetricsClientListOptions {
-	resType := strings.Join(metrics[start:end], ",")
-	filter := armmonitor.MetricsClientListOptions{
-		Metricnames: &resType,
+	return armmonitor.MetricsClientListOptions{
+		Metricnames: to.Ptr(strings.Join(metrics[start:end], ",")),
 		Interval:    to.Ptr(timeGrain),
 		Timespan:    to.Ptr(timeGrain),
 		Aggregation: to.Ptr(strings.Join(aggregations, ",")),
 		Top:         to.Ptr(top),
+		Filter:      buildDimensionsFilter(dimensionsStr),
 	}
-
-	if splitByDimensions && len(dimensionsStr) > 0 {
-		var dimensionsFilter bytes.Buffer
-		dimensions := strings.Split(dimensionsStr, ",")
-		for i, dimension := range dimensions {
-			dimensionsFilter.WriteString(dimension)
-			dimensionsFilter.WriteString(" eq '*' ")
-			if i < len(dimensions)-1 {
-				dimensionsFilter.WriteString(" and ")
-			}
-		}
-		dimensionFilterString := dimensionsFilter.String()
-		filter.Filter = &dimensionFilterString
-	}
-
-	return filter
 }
 
 func (s *azureScraper) processTimeseriesData(

--- a/receiver/azuremonitorreceiver/scraper_test.go
+++ b/receiver/azuremonitorreceiver/scraper_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
@@ -102,7 +101,6 @@ func TestAzureScraperStart(t *testing.T) {
 					MaximumNumberOfMetricsInACall: 20,
 					Services:                      monitorServices,
 					Authentication:                servicePrincipal,
-					SplitByDimensions:             to.Ptr(defaultSplitByDimensions),
 				}
 				s := &azureScraper{
 					cfg:                             customCfg,
@@ -131,7 +129,6 @@ func TestAzureScraperStart(t *testing.T) {
 					MaximumNumberOfMetricsInACall: 20,
 					Services:                      monitorServices,
 					Authentication:                workloadIdentity,
-					SplitByDimensions:             to.Ptr(defaultSplitByDimensions),
 				}
 				s := &azureScraper{
 					cfg:                             customCfg,
@@ -160,7 +157,6 @@ func TestAzureScraperStart(t *testing.T) {
 					MaximumNumberOfMetricsInACall: 20,
 					Services:                      monitorServices,
 					Authentication:                managedIdentity,
-					SplitByDimensions:             to.Ptr(defaultSplitByDimensions),
 				}
 				s := &azureScraper{
 					cfg:                             customCfg,
@@ -189,7 +185,6 @@ func TestAzureScraperStart(t *testing.T) {
 					MaximumNumberOfMetricsInACall: 20,
 					Services:                      monitorServices,
 					Authentication:                defaultCredentials,
-					SplitByDimensions:             to.Ptr(defaultSplitByDimensions),
 				}
 				s := &azureScraper{
 					cfg:                             customCfg,
@@ -741,8 +736,7 @@ func TestAzureScraperClientOptions(t *testing.T) {
 			name: "AzureCloud_options",
 			fields: fields{
 				cfg: &Config{
-					Cloud:             azureCloud,
-					SplitByDimensions: to.Ptr(defaultSplitByDimensions),
+					Cloud: azureCloud,
 				},
 			},
 			want: &arm.ClientOptions{
@@ -755,8 +749,7 @@ func TestAzureScraperClientOptions(t *testing.T) {
 			name: "AzureGovernmentCloud_options",
 			fields: fields{
 				cfg: &Config{
-					Cloud:             azureGovernmentCloud,
-					SplitByDimensions: to.Ptr(defaultSplitByDimensions),
+					Cloud: azureGovernmentCloud,
 				},
 			},
 			want: &arm.ClientOptions{
@@ -769,8 +762,7 @@ func TestAzureScraperClientOptions(t *testing.T) {
 			name: "AzureChinaCloud_options",
 			fields: fields{
 				cfg: &Config{
-					Cloud:             azureChinaCloud,
-					SplitByDimensions: to.Ptr(defaultSplitByDimensions),
+					Cloud: azureChinaCloud,
 				},
 			},
 			want: &arm.ClientOptions{


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR is a cherry pick of the original split by dimension PR of the upstream. To load it in our fork and benefit from it.

Currently we have only a global optin optout, but this new dimensions config is allowing fine grain tuning according to the type of the resources. This is useful for the problem mentioned in the README.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- [x] ~~I'd like to test locally the with / without split with all the resources. Like that I'll be able to isolate the resource types causing issues.~~ Getting all resource types metrics from all subscriptions is too consuming for my laptop. I have inconsistent result accross time. I will better activate the feature resource type by resource type in deployed test phases and build the list of metrics impacted progressively.

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
